### PR TITLE
Smash.gg endpoints

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,9 @@ val DoobieVersion = "0.12.1"
 
 enablePlugins(JavaAppPackaging)
 
+Test / parallelExecution := false
+Test / testOptions += Tests.Argument(TestFrameworks.MUnit, "-b")
+
 lazy val root = (project in file("."))
   .settings(
     organization := "io.github.locl95",

--- a/src/main/resources/db/migration/V1641305264__Tournaments_Migration.sql
+++ b/src/main/resources/db/migration/V1641305264__Tournaments_Migration.sql
@@ -1,0 +1,4 @@
+create table tournaments(
+    "id" integer not null primary key,
+    name text not null
+);

--- a/src/main/resources/db/migration/V1641397212__Entrants_Migration.sql
+++ b/src/main/resources/db/migration/V1641397212__Entrants_Migration.sql
@@ -1,0 +1,5 @@
+create table entrants(
+    "id" integer primary key,
+    id_event integer not null,
+    name text not null
+);

--- a/src/main/resources/db/migration/V1641399507__Events_Migration.sql
+++ b/src/main/resources/db/migration/V1641399507__Events_Migration.sql
@@ -1,0 +1,5 @@
+create table events(
+    "id" integer primary key,
+    name text not null,
+    "id_tournament" integer not null
+);

--- a/src/main/resources/db/migration/V1641553004__PlayerStandings_Migration.sql
+++ b/src/main/resources/db/migration/V1641553004__PlayerStandings_Migration.sql
@@ -1,0 +1,4 @@
+create table player_standings(
+    placement integer not null,
+    id_entrant integer not null
+);

--- a/src/main/resources/db/migration/V1641558803__Phases_Migration.sql
+++ b/src/main/resources/db/migration/V1641558803__Phases_Migration.sql
@@ -1,0 +1,4 @@
+create table phases(
+    id integer primary key,
+    name text not null
+);

--- a/src/main/resources/db/migration/V1644323326__Sets_Migration.sql
+++ b/src/main/resources/db/migration/V1644323326__Sets_Migration.sql
@@ -1,0 +1,8 @@
+create table sets(
+    "id" integer primary key,
+    id_event integer not null,
+    id_winner integer not null,
+    id_loser integer not null,
+    score_winner integer not null,
+    score_loser integer not null
+);

--- a/src/main/scala/io/github/locl95/smashtools/Runner.scala
+++ b/src/main/scala/io/github/locl95/smashtools/Runner.scala
@@ -5,7 +5,11 @@ import cats.effect.{ExitCode, IO, IOApp}
 object Runner extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
-    SmashtoolsServer.stream[IO].compile.drain.as(ExitCode.Success)
+    SmashtoolsServer
+      .stream[IO]
+      .compile
+      .drain
+      .as(ExitCode.Success)
   }
 
 }

--- a/src/main/scala/io/github/locl95/smashtools/SmashtoolsServer.scala
+++ b/src/main/scala/io/github/locl95/smashtools/SmashtoolsServer.scala
@@ -1,6 +1,7 @@
 package io.github.locl95.smashtools
 
 import cats.effect.{Async, ConcurrentEffect, ContextShift, Timer}
+import cats.implicits.toSemigroupKOps
 import fs2.Stream
 import org.http4s.implicits.http4sKleisliResponseSyntaxOptionT
 import org.http4s.server.blaze.BlazeServerBuilder
@@ -18,8 +19,9 @@ object SmashtoolsServer {
       database <- Stream.eval(context.databaseProgram)
       _ = database.flyway.migrate()
       charactersRoutes <- context.charactersRoutesProgram
+      smashggRoutes <- context.smashggRoutesProgram
 
-      httpApp = (charactersRoutes.characterRoutes).orNotFound
+      httpApp = (charactersRoutes.characterRoutes <+> smashggRoutes.smashggRoutes).orNotFound
 
       // With Middlewares in place
       finalHttpApp = Logger.httpApp(true, true)(httpApp)

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/SmashggClient.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/SmashggClient.scala
@@ -1,5 +1,6 @@
 package io.github.locl95.smashtools.smashgg
 
+
 import io.github.locl95.smashtools.smashgg.domain.SmashggQuery
 import org.http4s.Method.POST
 import org.http4s._
@@ -8,6 +9,8 @@ import org.http4s.implicits.http4sLiteralsSyntax
 
 trait SmashggClient[F[_]] {
   def get[A](body: SmashggQuery)(implicit encoder: EntityEncoder[F, SmashggQuery], decoder: EntityDecoder[F, A]): F[A]
+
+  override def toString: String = s"SmashggClient"
 }
 
 case class SmashggClientError(t: Throwable) extends RuntimeException
@@ -16,12 +19,7 @@ object SmashggClient {
 
   def impl[F[_]](C: Client[F]): SmashggClient[F] = new SmashggClient[F] {
 
-    def get[A](
-        body: SmashggQuery
-      )(
-        implicit encoder: EntityEncoder[F, SmashggQuery],
-        decoder: EntityDecoder[F, A]
-      ): F[A] = {
+    override def get[A](body: SmashggQuery)(implicit encoder: EntityEncoder[F, SmashggQuery], decoder: EntityDecoder[F, A]): F[A] = {
       val headers = Headers.apply(
         Header("Authorization", "Bearer 3305177ceda157c60fbc09b79e2ff987")
       )
@@ -30,5 +28,6 @@ object SmashggClient {
 
       C.expect[A](request)
     }
+
   }
 }

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/SmashggRoutes.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/SmashggRoutes.scala
@@ -1,0 +1,120 @@
+package io.github.locl95.smashtools.smashgg
+
+import cats.effect.Async
+import cats.implicits._
+import io.circe.syntax._
+import io.github.locl95.smashtools.smashgg.domain._
+import io.github.locl95.smashtools.smashgg.protocol.SmashggRoutesImpl._
+import io.github.locl95.smashtools.smashgg.service._
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.Authorization
+import org.http4s.{Header, HttpRoutes}
+
+final class SmashggRoutes[F[_]: Async](tournamentService: TournamentService[F],
+                                       eventService: EventService[F],
+                                       entrantService: EntrantService[F],
+                                       phaseService: PhaseService[F],
+                                       setsService: SetsService[F]) extends Http4sDsl[F]{
+
+  val smashggRoutes: HttpRoutes[F] = {
+    HttpRoutes.of[F] {
+      case req @ POST -> Root / "tournaments" =>
+
+        val header: Option[Header] = req.headers.get(Authorization)
+        header match {
+          case Some(h) => h.value match {
+            case "Bearer 3305177ceda157c60fbc09b79e2ff987" =>
+              for {
+                r <- req.as[Tournament]
+                i <- tournamentService.insert(r)
+                resp <- Ok(i.asJson)
+            } yield resp
+
+            case _ => Forbidden()
+          }
+          case None => Forbidden()//hauria de ser unauth
+        }
+
+
+      case GET -> Root / "tournaments" / tournament =>
+        for {
+          maybeTournament <- tournamentService.getTournament(tournament.toInt)
+          resp <- maybeTournament match {
+            case Some(value) => Ok(value.asJson).adaptError(SmashggClientError(_))
+            case None => NotFound()
+          }
+        } yield resp
+
+      case GET -> Root / "tournaments" =>
+        for {
+          tournaments <- tournamentService.get
+          resp <- Ok(tournaments.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case req @ POST -> Root / "tournaments" / tournamentID / "events" =>
+        for {
+          r <- req.as[Event]
+          i <- eventService.insert(tournamentID.toInt, r)
+          resp <- Ok(i.asJson)
+        } yield resp
+
+      case GET -> Root / "events" =>
+        for {
+          events <- eventService.get
+          resp <- Ok(events.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case GET -> Root / "tournaments" / tournamentID / "events" =>
+        for {
+          events <- eventService.getEvents(tournamentID.toInt)
+          resp <- Ok(events.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case req @ POST -> Root / "events" / "entrants" =>
+        for {
+          entrants <- req.as[List[Entrant]]
+          i <- entrantService.insert(entrants)
+          resp <- Ok(i.asJson)
+        } yield resp
+
+      case GET -> Root / "events" / "entrants" =>
+        for {
+          entrants <- entrantService.getEntrants
+          resp <- Ok(entrants.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case GET -> Root / "events" / eventID / "entrants" =>
+        for{
+          entrants <- entrantService.getEntrants(eventID.toInt)
+          resp <- Ok(entrants.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case req @ POST -> Root / "phases" =>
+        for {
+          r <- req.as[List[Phase]]
+          i <- phaseService.insert(r)
+          resp <- Ok(i.asJson)
+        } yield resp
+
+      case GET -> Root / "phases" =>
+        for {
+          phases <- phaseService.getPhases
+          resp <- Ok(phases.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+
+      case req @ POST -> Root / "sets" =>
+        for {
+          r <- req.as[List[Sets]]
+          i <- setsService.insert(r)
+          resp <- Ok(i.asJson)
+        } yield resp
+
+      case GET -> Root / "sets" =>
+        for {
+          sets <- setsService.getSets
+          resp <- Ok(sets.asJson).adaptError(SmashggClientError(_))
+        } yield resp
+    }
+  }
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/domain/Smashgg.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/domain/Smashgg.scala
@@ -1,8 +1,10 @@
 package io.github.locl95.smashtools.smashgg.domain
 
-case class Tournament(name: String)
-case class Participant(ids: List[Int])
-case class Event(name: String)
-case class Entrant(name: String)
+case class Tournament(id:Int, name: String)
+case class Participant(ids: List[Int]) //Players
+case class Event(id:Int, name: String, idTournament: Int = 0)
+case class Entrant(id:Int, idEvent:Int, name: String)
 case class PlayerStanding(placement: Int, idEntrant: Int)
 case class Phase(id: Int, name:String)
+case class Sets(id:Int, idEvent:Int, scores: List[Score])
+case class Score(idPlayer: Int, score: Int)

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/protocol/Smashgg.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/protocol/Smashgg.scala
@@ -4,22 +4,31 @@ import cats.Traverse
 import cats.effect.Sync
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.{Decoder, Encoder, HCursor, Json}
-import io.github.locl95.smashtools.smashgg.domain.{Entrant, Event, Participant, Phase, PlayerStanding, SmashggQuery, Tournament}
+import io.github.locl95.smashtools.smashgg.domain.{Entrant, Event, Participant, Phase, PlayerStanding, Score, Sets, SmashggQuery, Tournament}
 import org.http4s.circe.{jsonEncoderOf, jsonOf}
 import org.http4s.{EntityDecoder, EntityEncoder}
 
 object Smashgg {
   implicit val smashggQueryEncoder: Encoder[SmashggQuery] = deriveEncoder[SmashggQuery]
-
   implicit def smashggQueryEntityEncoder[F[_]]: EntityEncoder[F, SmashggQuery] = jsonEncoderOf
+
+
 
   implicit val tournamentDecoder: Decoder[Tournament] = (c: HCursor) => {
     for {
-      name <- c.downField("data").downField("tournament").downField("name").as[String]
-    } yield Tournament(name)
+      id <- c.downField("data").downField("tournament").downField("id").as[Int]
+      slug <- c.downField("data").downField("tournament").downField("slug").as[String]
+    } yield
+      Tournament(
+        id,
+        slug.split("/").toList.last.toUpperCase
+      )
   }
-
-  implicit def tournamentEntityDecoder[F[_] : Sync]: EntityDecoder[F, Tournament] = jsonOf
+  implicit val tournamentsDecoder: Decoder[List[Tournament]] = Decoder.decodeList[Tournament]
+  implicit def tournamentEntityDecoder[F[_]: Sync]: EntityDecoder[F, Tournament] = jsonOf
+  implicit def tournamentsEntityDecoder[F[_]: Sync]: EntityDecoder[F, List[Tournament]] = jsonOf
+  implicit val tournamentEncoder: Encoder[Tournament] = deriveEncoder[Tournament]
+  implicit val tournamentsEncoder: Encoder[List[Tournament]] = Encoder.encodeList
 
   implicit val participantsDecoder: Decoder[List[Participant]] = (c: HCursor) => {
     for {
@@ -62,31 +71,35 @@ object Smashgg {
         }
     } yield ids.flatten.map(Participant)
   }
-
   implicit def participantsEntityDecoder[F[_] : Sync]: EntityDecoder[F, List[Participant]] = jsonOf
-
   implicit val eventDecoder: Decoder[Event] = (c: HCursor) => {
     for {
+      id <- c.downField("data").downField("event").downField("id").as[Int]
       name <- c.downField("data").downField("event").downField("name").as[String]
-    } yield Event(name)
+    } yield Event(id, name)
   }
-
   implicit def eventEntityDecoder[F[_] : Sync]: EntityDecoder[F, Event] = jsonOf
 
   implicit val entrantsDecoder: Decoder[List[Entrant]] = (c: HCursor) => {
     for {
+      idEvent <- c
+        .downField("data")
+        .downField("event")
+        .downField("id").as[Int]
       nodes <- c
         .downField("data")
         .downField("event")
         .downField("entrants")
         .downField("nodes")
         .as[List[Json]]
-      entrants <- Traverse[List].traverse(nodes) { item =>
+      entrantsName <- Traverse[List].traverse(nodes) { item =>
         item.hcursor.downField("name").as[String]
       }
-    } yield entrants.map(x => Entrant(x))
+      entrantsId <- Traverse[List].traverse(nodes) {
+        item => item.hcursor.downField("id").as[Int]
+      }
+    } yield entrantsName.zip(entrantsId).map(x => Entrant(x._2, idEvent, x._1))
   }
-
   implicit def entrantsEntityDecoder[F[_] : Sync]: EntityDecoder[F, List[Entrant]] = jsonOf
 
   implicit val standingsDecoder: Decoder[List[PlayerStanding]] = (c: HCursor) => {
@@ -108,7 +121,6 @@ object Smashgg {
       }
     } yield playerPlacements.zip(idEntrant).map(x => PlayerStanding(x._1, x._2))
   }
-
   implicit def standingsEntityDecoder[F[_] : Sync]: EntityDecoder[F, List[PlayerStanding]] = jsonOf
 
   implicit val phasesDecoder: Decoder[List[Phase]] = (c: HCursor) => {
@@ -126,6 +138,59 @@ object Smashgg {
       }
     } yield id.zip(name).map(x => Phase(x._1, x._2))
   }
-
   implicit def phaseEntityDecoder[F[_] : Sync]: EntityDecoder[F, List[Phase]] = jsonOf
+
+  implicit val setsDecoder: Decoder[List[Sets]] = (c: HCursor) => {
+    for {
+      idEvent <- c
+        .downField("data")
+        .downField("event")
+        .downField("id")
+        .as[Int]
+
+      nodes <- c
+        .downField("data")
+        .downField("event")
+        .downField("sets")
+        .downField("nodes")
+        .as[List[Json]]
+
+      idSets <- Traverse[List].traverse(nodes) {
+        item => item.hcursor.downField("id").as[Int]
+      }
+
+      slots <- Traverse[List].traverse(nodes) {
+        item => item.hcursor
+          .downField("slots")
+          .as[List[Json]]
+      }
+
+      idPlayers <- Traverse[List].traverse(slots) {
+        item => Traverse[List].traverse(item) {
+          i => i.hcursor
+            .downField("entrant")
+            .downField("id")
+            .as[Int]
+        }
+      }
+
+      scorePlayers <- Traverse[List].traverse(slots) {
+        item => Traverse[List].traverse(item) {
+          i => i.hcursor
+            .downField("standing")
+            .downField("stats")
+            .downField("score")
+            .downField("value")
+            .as[Int]
+        }
+      }
+    } yield {
+      val scores = idPlayers.zip(scorePlayers).map{
+        case (id1 :: id2 :: Nil, s1 :: s2 :: Nil) => List(Score(id1, s1), Score(id2, s2))
+        case _ => List(Score(0,0), Score(0,0)) //retornar DecodingFailure
+      }
+      idSets.zip(scores).map(x => Sets(x._1, idEvent, x._2))
+    }
+  }
+  implicit def setsEntityDecoder[F[_] : Sync]: EntityDecoder[F, List[Sets]] = jsonOf
 }

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/protocol/SmashggRoutesImpl.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/protocol/SmashggRoutesImpl.scala
@@ -1,0 +1,32 @@
+package io.github.locl95.smashtools.smashgg.protocol
+
+import cats.effect.Async
+import io.circe.generic.auto._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import io.github.locl95.smashtools.smashgg.domain._
+import org.http4s.EntityDecoder
+import org.http4s.circe.jsonOf
+
+object SmashggRoutesImpl {
+  implicit val decoderForTournament: Decoder[Tournament] = deriveDecoder[Tournament]
+  implicit def entityDecoderForTournament[F[_]: Async]: EntityDecoder[F, Tournament] = jsonOf
+  implicit val encoderForTournament: Encoder[Tournament] = deriveEncoder[Tournament]
+
+  implicit val decoderForEvent: Decoder[Event] = deriveDecoder[Event]
+  implicit def entityDecoderForEvent[F[_]: Async]: EntityDecoder[F, Event] = jsonOf
+  implicit val encoderForEvent: Encoder[Event] = deriveEncoder[Event]
+
+  implicit val decoderForEntrants: Decoder[List[Entrant]] = Decoder.decodeList[Entrant]
+  implicit def entityDecoderForEntrants[F[_]: Async]: EntityDecoder[F, List[Entrant]] = jsonOf
+  implicit val encoderForEntrants: Encoder[List[Entrant]] = Encoder.encodeList[Entrant]
+
+  implicit val decoderForPhases: Decoder[List[Phase]] = Decoder.decodeList[Phase]
+  implicit def entityDecoderForPhases[F[_]: Async]: EntityDecoder[F, List[Phase]] = jsonOf
+  implicit val encoderForPhases: Encoder[List[Phase]] = Encoder.encodeList[Phase]
+
+  implicit val decoderForSets: Decoder[List[Sets]] = Decoder.decodeList[Sets]
+  implicit def entityDecoderForSets[F[_]: Async]: EntityDecoder[F, List[Sets]] = jsonOf
+  implicit val encoderForSets: Encoder[List[Sets]] = Encoder.encodeList[Sets]
+
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/EntrantRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/EntrantRepository.scala
@@ -1,0 +1,37 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.Update
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.Entrant
+
+trait EntrantRepository[F[_]] {
+  def insert(entrants: List[Entrant]): F[Int]
+  def getEntrants: F[List[Entrant]]
+  def getEntrants(eventID:Int): F[List[Entrant]]
+}
+
+final class EntrantPostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends EntrantRepository[F]{
+  override def toString: String = "EntrantPostgresRepository"
+  override def insert(entrants: List[Entrant]): F[Int] = {
+    val sql = "insert into entrants (id, id_event, name) values (?, ?, ?)"
+    Update[Entrant](sql)
+      .updateMany(entrants)
+      .transact(transactor)
+  }
+
+  override def getEntrants: F[List[Entrant]] =
+    sql"""select id,id_event,name from entrants"""
+      .query[Entrant]
+      .to[List]
+      .transact(transactor)
+
+  override def getEntrants(eventID: Int): F[List[Entrant]] =
+    sql"""select id,id_event,name from entrants where id_event = ${eventID}"""
+      .query[Entrant]
+      .to[List]
+      .transact(transactor)
+
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/EventRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/EventRepository.scala
@@ -1,0 +1,34 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.Event
+
+trait EventRepository [F[_]]{
+  def insert(event: Event): F[Int]
+  def get: F[List[Event]]
+  def getEvents(tournament:Int): F[List[Event]]
+}
+
+final class EventPostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends EventRepository[F]{
+  override def toString: String = "EventPostgresRepository"
+
+  override def insert(event: Event): F[Int] =
+    sql"insert into events (id,name,id_tournament) values (${event.id}, ${event.name}, ${event.idTournament})"
+      .update.withUniqueGeneratedKeys[Int]("id")
+      .transact(transactor)
+
+  override def getEvents(tournament: Int): F[List[Event]] = {
+    sql"select id, name, id_tournament from events where id_tournament = ${tournament}"
+      .query[Event]
+      .to[List]
+      .transact(transactor)
+  }
+
+  override def get: F[List[Event]] =
+    sql"select * from events"
+      .query[Event]
+      .to[List]
+      .transact(transactor)
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/PhaseRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/PhaseRepository.scala
@@ -1,0 +1,34 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.Update
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.{Phase}
+
+trait PhaseRepository [F[_]]{
+  def insert(phases: List[Phase]): F[Int]
+  def getPhases: F[List[Phase]]
+}
+
+final class PhasePostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends PhaseRepository[F]{
+  override def toString: String = "PlayerStandingPostgresRepository"
+  override def insert(playerStandings: List[Phase]): F[Int] = {
+    val sql = "insert into phases (id, name) values (?,?)"
+    Update[Phase](sql)
+      .updateMany(playerStandings)
+      .transact(transactor)
+  }
+
+  override def getPhases: F[List[Phase]] =
+    sql"select id,name from phases"
+      .query[Phase]
+      .to[List]
+      .transact(transactor)
+}
+
+
+
+
+

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/PlayerStandingRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/PlayerStandingRepository.scala
@@ -1,0 +1,29 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.Update
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.PlayerStanding
+
+trait PlayerStandingRepository [F[_]]{
+  def insert(playerStandings: List[PlayerStanding]): F[Int]
+  def getPlayerStandings: F[List[PlayerStanding]]
+}
+
+final class PlayerStandingPostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends PlayerStandingRepository[F]{
+  override def toString: String = "PlayerStandingPostgresRepository"
+  override def insert(playerStandings: List[PlayerStanding]): F[Int] = {
+    val sql = "insert into player_standings (placement, id_entrant) values (?,?)"
+    Update[PlayerStanding](sql)
+      .updateMany(playerStandings)
+      .transact(transactor)
+  }
+
+  override def getPlayerStandings: F[List[PlayerStanding]] =
+    sql"select placement,id_entrant from player_standings"
+      .query[PlayerStanding]
+      .to[List]
+      .transact(transactor)
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/SetsRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/SetsRepository.scala
@@ -1,0 +1,44 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.Update
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.{Score, Sets}
+
+trait SetsRepository [F[_]]{
+  def insert(sets: List[Sets]): F[Int]
+  def getSets: F[List[Sets]]
+}
+
+case class sqlSet(id:Int, idEvent:Int, idWinner:Int, idLoser:Int, scoreWinner:Int, scoreLoser:Int)
+
+final class SetsPostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends SetsRepository[F]{
+  override def toString: String = "SetsPostgresRepository"
+  override def insert(sets: List[Sets]): F[Int] = {
+
+    val sqlSets = sets.map{
+      case Sets(id, idEvent, scores) =>
+        if (scores.head.score > scores.tail.head.score)
+          sqlSet(id, idEvent, scores.head.idPlayer, scores.tail.head.idPlayer, scores.head.score, scores.tail.head.score)
+        else
+          sqlSet(id, idEvent, scores.tail.head.idPlayer, scores.head.idPlayer, scores.tail.head.score, scores.head.score)
+    }
+
+    val sql = "insert into sets (id, id_event, id_winner, id_loser, score_winner, score_loser) values (?,?,?,?,?,?)"
+    Update[sqlSet](sql)
+      .updateMany(sqlSets)
+      .transact(transactor)
+  }
+
+  override def getSets: F[List[Sets]] =
+    sql"select id, id_event, id_winner, id_loser, score_winner, score_loser from sets"
+      .query[sqlSet]
+      .to[List]
+      .transact(transactor)
+      .map(x => x.map{
+        case sqlSet(id, idEvent, idWinner, idLoser, scoreWinner, scoreLoser) =>
+          Sets(id, idEvent, List(Score(idWinner, scoreWinner), Score(idLoser, scoreLoser)))
+      })
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/repository/TournamentRepository.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/repository/TournamentRepository.scala
@@ -1,0 +1,35 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.Sync
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.github.locl95.smashtools.smashgg.domain.Tournament
+
+trait TournamentRepository[F[_]] {
+  def insert(tournament: Tournament): F[Int]
+  def get: F[List[Tournament]]
+  def get(tournamentId: Int): F[Option[Tournament]]
+}
+
+final class TournamentPostgresRepository[F[_]: Sync](transactor: Transactor[F]) extends TournamentRepository[F] {
+  override def toString: String = "TournamentPostgresRepository"
+
+  override def insert(tournament: Tournament): F[Int] =
+    sql"insert into tournaments (id,name) values (${tournament.id}, ${tournament.name})"
+      .update
+      .withUniqueGeneratedKeys[Int]("id")
+      .transact(transactor)
+
+  override def get: F[List[Tournament]] =
+    sql"select id,name from tournaments"
+      .query[Tournament]
+      .to[List]
+      .transact(transactor)
+
+  override def get(tournamentId: Int): F[Option[Tournament]] =
+    sql"""select id,name from tournaments where id = ${tournamentId}"""
+      .query[Tournament]
+      .option
+      .transact(transactor)
+
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/service/EntrantService.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/service/EntrantService.scala
@@ -1,0 +1,19 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import io.github.locl95.smashtools.smashgg.SmashggClient
+import io.github.locl95.smashtools.smashgg.domain.Entrant
+import io.github.locl95.smashtools.smashgg.repository.EntrantRepository
+
+final case class EntrantService[F[_]](entrantRepository: EntrantRepository[F],
+                                      client: SmashggClient[F]){
+
+  def insert(entrants: List[Entrant]): F[Int] =
+    entrantRepository.insert(entrants)
+
+  def getEntrants: F[List[Entrant]] =
+    entrantRepository.getEntrants
+
+  def getEntrants(eventID: Int): F[List[Entrant]] =
+    entrantRepository.getEntrants(eventID)
+}
+

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/service/EventService.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/service/EventService.scala
@@ -1,0 +1,18 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import io.github.locl95.smashtools.smashgg.SmashggClient
+import io.github.locl95.smashtools.smashgg.domain.Event
+import io.github.locl95.smashtools.smashgg.repository.EventRepository
+
+final case class EventService[F[_]](eventRepository: EventRepository[F],
+                                    client: SmashggClient[F]) {
+
+    def insert(tournamedID:Int, event: Event): F[Int] =
+      eventRepository.insert(Event(event.id, event.name, tournamedID))
+
+    def get: F[List[Event]] =
+      eventRepository.get
+
+    def getEvents(tournament: Int): F[List[Event]] =
+      eventRepository.getEvents(tournament)
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/service/PhaseService.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/service/PhaseService.scala
@@ -1,0 +1,15 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import io.github.locl95.smashtools.smashgg.SmashggClient
+import io.github.locl95.smashtools.smashgg.domain.Phase
+import io.github.locl95.smashtools.smashgg.repository.PhaseRepository
+
+final case class PhaseService[F[_]](phaseRepository: PhaseRepository[F],
+                                    client: SmashggClient[F]) {
+
+  def insert(phases: List[Phase]): F[Int] =
+    phaseRepository.insert(phases)
+
+  def getPhases: F[List[Phase]] =
+    phaseRepository.getPhases
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/service/SetsService.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/service/SetsService.scala
@@ -1,0 +1,15 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import io.github.locl95.smashtools.smashgg.SmashggClient
+import io.github.locl95.smashtools.smashgg.domain.Sets
+import io.github.locl95.smashtools.smashgg.repository.SetsRepository
+
+final case class SetsService[F[_]](setsRepository: SetsRepository[F],
+                                   client: SmashggClient[F]){
+
+  def insert(sets: List[Sets]): F[Int] =
+    setsRepository.insert(sets)
+
+  def getSets: F[List[Sets]] =
+    setsRepository.getSets
+}

--- a/src/main/scala/io/github/locl95/smashtools/smashgg/service/TournamentService.scala
+++ b/src/main/scala/io/github/locl95/smashtools/smashgg/service/TournamentService.scala
@@ -1,0 +1,19 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import io.github.locl95.smashtools.smashgg.SmashggClient
+import io.github.locl95.smashtools.smashgg.domain.Tournament
+import io.github.locl95.smashtools.smashgg.repository.TournamentRepository
+
+final case class TournamentService[F[_]](tournamentRepository: TournamentRepository[F],
+                                               client: SmashggClient[F]) {
+
+  def insert(tournament: Tournament): F[Int] =
+    tournamentRepository.insert(tournament)
+
+  def getTournament(tournamentID: Int): F[Option[Tournament]] =
+    tournamentRepository.get(tournamentID)
+
+  def get: F[List[Tournament]] =
+    tournamentRepository.get
+
+}

--- a/src/test/resources/smashgg/Smashgg_graphql_model.php
+++ b/src/test/resources/smashgg/Smashgg_graphql_model.php
@@ -1,0 +1,116 @@
+<?php
+
+class Smashgg_graphql_model extends CI_Model {
+
+    private $ch;
+    private $graphQLUrl = 'https://api.smash.gg/gql/alpha';
+
+    private function api_call($data){
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $this->graphQLUrl);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json', 'Authorization: Bearer '.SMASHGG_TOKEN));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($data));
+        $result = curl_exec($ch);
+        if ($result === FALSE) {
+            die('Curl failed: ' . curl_error($ch));
+        }
+        curl_close($ch);
+        return $result;
+    }
+
+    public function get_tournament($tournament){
+        $data = array("query" => "query getTournament {tournament(slug: \"$tournament\") {id name slug venueName images {type url} events {id name slug videogame { id } entrantSizeMin } startAt endAt}}");
+        $result = $this->api_call($data);
+        return  json_decode($result)->data->tournament;
+    }
+
+    public function get_participants($tournament){
+        $data = array("query" => "query getParticipants {tournament(slug: \"$tournament\") { participants(query : {perPage: 300}) { nodes { entrants { participants { id player { id } } event { id } }}} }}");
+        $result = $this->api_call($data);
+        $result = json_decode($result);
+
+        if ($result->data->tournament != null) {
+            return array_reduce($result->data->tournament->participants->nodes,
+            function($carry, $node) {
+                if($node->entrants == null){
+                    return $carry;
+                }
+                else {
+                    return array_merge($carry, array_map(function($entrant) {
+                        $entrant->participants = array_map(function($v){return $v->player->id; }, $entrant->participants);
+                        return $entrant;
+                    }, $node->entrants));
+                }
+            }, array());
+        } else {
+            return array();
+        }
+    }
+
+    public function get_event($tournament,$event){
+        $pag = 1;
+        $result = null;
+        do {
+            $data = array("query" => "query getTournament {event(slug: \"tournament/$tournament/event/$event\")  { name state id sets (page:$pag perPage: 50){ nodes { id  phaseGroup { id }  round identifier totalGames fullRoundText  completedAt  slots { entrant { id name} standing { stats { score {value}}}} }} }}");
+            $resultPage = json_decode($this->api_call($data));
+            // if ($resultPage->data->event->state != "CREATED") {
+            //     break;
+            // }
+            if ($result != null) {
+                $result->data->event->sets->nodes = array_merge($result->data->event->sets->nodes, $resultPage->data->event->sets->nodes);
+            } else {
+                $result = $resultPage;
+            }
+            $pag+=1;
+        } while ($result->data->event != null &&  count($resultPage->data->event->sets->nodes) == 50);
+
+        return $result->data->event;
+    }
+
+    public function get_entrants($tournament,$event){
+        $data = array("query" => "query getEntrants {event(slug: \"tournament/$tournament/event/$event\") { id entrants(query: {perPage: 500}) { nodes { id name participants { id player { id } } }}}}");
+        $result = $this->api_call($data);
+        $result = json_decode($result);
+        if ($result->data->event != null) {
+            $fixEntrants = array_map(function($node) {
+                $node->participants = array_map(function($v){return $v->player->id; }, $node->participants);
+                return $node;
+            }, $result->data->event->entrants->nodes);
+            return array("eventId" => $result->data->event->id, "entrants" => $fixEntrants);
+        } else {
+            return array();
+        }
+        
+    }
+
+    public function get_phases($tournament, $event) {
+        $data = array("query" => "query getPhases{event(slug: \"tournament/$tournament/event/$event\") { phases { id name bracketType phaseGroups { nodes { id wave { id } }}}}}");
+        $result = $this->api_call($data);
+        return  json_decode($result)->data->event->phases;
+    }
+
+    public function get_standings($tournament,$event){
+        $pag = 1;
+        $result = null;
+        do {
+            $data =  array("query" => "query getTournament {event(slug: \"tournament/$tournament/event/$event\") { id standings(query: {page: $pag perPage: 50} ) { nodes { placement entrant { id participants { gamerTag player { id }}}}}}}");
+            $resultPage = json_decode($this->api_call($data));
+            if ($resultPage->data->event->standings->nodes == null) {
+                break;
+            }
+
+            if ($result != null) {
+                $result->data->event->standings->nodes = array_merge($result->data->event->standings->nodes, $resultPage->data->event->standings->nodes);
+            } else {
+                $result = $resultPage;
+            }
+            $pag+=1;
+        } while ($result->data->event != null &&  count($resultPage->data->event->standings->nodes) == 50);
+        return $result->data->event->standings->nodes;
+    }
+}
+
+?>

--- a/src/test/resources/smashgg/decoded-smashgg-entrants.json
+++ b/src/test/resources/smashgg/decoded-smashgg-entrants.json
@@ -1,0 +1,232 @@
+[
+  {
+    "id" : 8348984,
+    "idEvent" : 615463,
+    "name" : "Raiden's | Zandark"
+  },
+  {
+    "id" : 8346516,
+    "idEvent" : 615463,
+    "name" : "FS | Sevro"
+  },
+  {
+    "id" : 8338996,
+    "idEvent" : 615463,
+    "name" : "Rextone"
+  },
+  {
+    "id" : 8338417,
+    "idEvent" : 615463,
+    "name" : "Foxy"
+  },
+  {
+    "id" : 8332947,
+    "idEvent" : 615463,
+    "name" : "Kiro"
+  },
+  {
+    "id" : 8331682,
+    "idEvent" : 615463,
+    "name" : "dammer"
+  },
+  {
+    "id" : 8331515,
+    "idEvent" : 615463,
+    "name" : "Mik"
+  },
+  {
+    "id" : 8330916,
+    "idEvent" : 615463,
+    "name" : "Jorah"
+  },
+  {
+    "id" : 8319533,
+    "idEvent" : 615463,
+    "name" : "LC | Link_Z"
+  },
+  {
+    "id" : 8316911,
+    "idEvent" : 615463,
+    "name" : "ElSantoGTZ"
+  },
+  {
+    "id" : 8303328,
+    "idEvent" : 615463,
+    "name" : "Quique"
+  },
+  {
+    "id" : 8287203,
+    "idEvent" : 615463,
+    "name" : "Nekuness"
+  },
+  {
+    "id" : 8286867,
+    "idEvent" : 615463,
+    "name" : "Casy"
+  },
+  {
+    "id" : 8280761,
+    "idEvent" : 615463,
+    "name" : "OST | Kynois"
+  },
+  {
+    "id" : 8280705,
+    "idEvent" : 615463,
+    "name" : "CMT | Pocafeiner"
+  },
+  {
+    "id" : 8280489,
+    "idEvent" : 615463,
+    "name" : "VGIA | MVL"
+  },
+  {
+    "id" : 8266055,
+    "idEvent" : 615463,
+    "name" : "Lacarta"
+  },
+  {
+    "id" : 8252439,
+    "idEvent" : 615463,
+    "name" : "DMP | Darío"
+  },
+  {
+    "id" : 8251399,
+    "idEvent" : 615463,
+    "name" : "LC | Vilxs"
+  },
+  {
+    "id" : 8246323,
+    "idEvent" : 615463,
+    "name" : "RoberWars"
+  },
+  {
+    "id" : 8245276,
+    "idEvent" : 615463,
+    "name" : "*FER*"
+  },
+  {
+    "id" : 8242867,
+    "idEvent" : 615463,
+    "name" : "Raiden's | aston"
+  },
+  {
+    "id" : 8242154,
+    "idEvent" : 615463,
+    "name" : "Diedan"
+  },
+  {
+    "id" : 8241837,
+    "idEvent" : 615463,
+    "name" : "DAC power"
+  },
+  {
+    "id" : 8241084,
+    "idEvent" : 615463,
+    "name" : "RamonWars"
+  },
+  {
+    "id" : 8241064,
+    "idEvent" : 615463,
+    "name" : "Akuex"
+  },
+  {
+    "id" : 8240251,
+    "idEvent" : 615463,
+    "name" : "LC | Ghandy el Dandy"
+  },
+  {
+    "id" : 8239875,
+    "idEvent" : 615463,
+    "name" : "LC | Monchi"
+  },
+  {
+    "id" : 8239850,
+    "idEvent" : 615463,
+    "name" : "Spize"
+  },
+  {
+    "id" : 8239744,
+    "idEvent" : 615463,
+    "name" : "OmegaPit"
+  },
+  {
+    "id" : 8239632,
+    "idEvent" : 615463,
+    "name" : "DR.DVD"
+  },
+  {
+    "id" : 8239568,
+    "idEvent" : 615463,
+    "name" : "Garrote"
+  },
+  {
+    "id" : 8239397,
+    "idEvent" : 615463,
+    "name" : "YI BI YI SI"
+  },
+  {
+    "id" : 8239376,
+    "idEvent" : 615463,
+    "name" : "LC | Osuma"
+  },
+  {
+    "id" : 8239145,
+    "idEvent" : 615463,
+    "name" : "Zilva"
+  },
+  {
+    "id" : 8239113,
+    "idEvent" : 615463,
+    "name" : "WBYB | Pepo"
+  },
+  {
+    "id" : 8239088,
+    "idEvent" : 615463,
+    "name" : "WIZ | AndresFn"
+  },
+  {
+    "id" : 8239048,
+    "idEvent" : 615463,
+    "name" : "LC | C-bus"
+  },
+  {
+    "id" : 8239022,
+    "idEvent" : 615463,
+    "name" : "Falcon Poncho"
+  },
+  {
+    "id" : 8238992,
+    "idEvent" : 615463,
+    "name" : "Tropped"
+  },
+  {
+    "id" : 8238189,
+    "idEvent" : 615463,
+    "name" : "MYS | MTsergi"
+  },
+  {
+    "id" : 8238163,
+    "idEvent" : 615463,
+    "name" : "MYS | Ark Klemens"
+  },
+  {
+    "id" : 8234478,
+    "idEvent" : 615463,
+    "name" : "TJ"
+  },
+  {
+    "id" : 8233149,
+    "idEvent" : 615463,
+    "name" : "marcpq"
+  },
+  {
+    "id" : 8232866,
+    "idEvent" : 615463,
+    "name" : "sisqui"
+  },
+  {
+    "id" : 8232833,
+    "idEvent" : 615463,
+    "name" : "Marcbri"
+  }
+]

--- a/src/test/resources/smashgg/smashgg-tournament.json
+++ b/src/test/resources/smashgg/smashgg-tournament.json
@@ -1,1 +1,58 @@
-{"data":{"tournament":{"id":312932,"name":"MST 4","slug":"tournament\/mst-4","venueName":null,"images":[{"type":"profile","url":"https:\/\/images.smash.gg\/images\/tournament\/312932\/image-7b2c1e9f776174fa861f60f63130ed16.jpg"},{"type":"banner","url":"https:\/\/images.smash.gg\/images\/tournament\/312932\/image-657ba6e13fd5d6aa4032f45b1f050839.jpg"}],"events":[{"id":615469,"name":"Teams","slug":"tournament\/mst-4\/event\/teams","videogame":{"id":1386},"entrantSizeMin":2},{"id":615463,"name":"Ultimate Singles","slug":"tournament\/mst-4\/event\/ultimate-singles","videogame":{"id":1386},"entrantSizeMin":1}],"startAt":1632560400,"endAt":1632682800}},"extensions":{"cacheControl":{"version":1,"hints":[{"path":["tournament"],"maxAge":300,"scope":"PRIVATE"}]},"queryComplexity":7},"actionRecords":[]}
+{
+  "data": {
+    "tournament": {
+      "id": 312932,
+      "name": "MST 4",
+      "slug": "tournament/mst-4",
+      "venueName": null,
+      "images": [
+        {
+          "type": "profile",
+          "url": "https://images.smash.gg/images/tournament/312932/image-7b2c1e9f776174fa861f60f63130ed16.jpg"
+        },
+        {
+          "type": "banner",
+          "url": "https://images.smash.gg/images/tournament/312932/image-657ba6e13fd5d6aa4032f45b1f050839.jpg"
+        }
+      ],
+      "events": [
+        {
+          "id": 615469,
+          "name": "Teams",
+          "slug": "tournament/mst-4/event/teams",
+          "videogame": {
+            "id": 1386
+          },
+          "entrantSizeMin": 2
+        },
+        {
+          "id": 615463,
+          "name": "Ultimate Singles",
+          "slug": "tournament/mst-4/event/ultimate-singles",
+          "videogame": {
+            "id": 1386
+          },
+          "entrantSizeMin": 1
+        }
+      ],
+      "startAt": 1632560400,
+      "endAt": 1632682800
+    }
+  },
+  "extensions": {
+    "cacheControl": {
+      "version": 1,
+      "hints": [
+        {
+          "path": [
+            "tournament"
+          ],
+          "maxAge": 300,
+          "scope": "PRIVATE"
+        }
+      ]
+    },
+    "queryComplexity": 7
+  },
+  "actionRecords": []
+}

--- a/src/test/scala/io/github/locl95/smashtools/characters/CharactersRoutesSpecs.scala
+++ b/src/test/scala/io/github/locl95/smashtools/characters/CharactersRoutesSpecs.scala
@@ -7,7 +7,7 @@ import io.github.locl95.smashtools.characters.domain.{KuroganeCharacter, Kurogan
 import io.github.locl95.smashtools.characters.service.{CharactersService, MovementsService}
 import munit.CatsEffectSuite
 import org.http4s.implicits.{http4sKleisliResponseSyntaxOptionT, http4sLiteralsSyntax}
-import org.http4s.{EntityDecoder, Method, Request, Status}
+import org.http4s.{EntityDecoder, HttpRoutes, Method, Request, Response, Status}
 import io.github.locl95.smashtools.characters.protocol.Kurogane.kuroganeCharactersEntityDecoder
 import org.http4s.circe.jsonOf
 
@@ -21,13 +21,13 @@ class CharactersRoutesSpecs extends CatsEffectSuite {
   private val modifiedEntityDecoderForMoves: EntityDecoder[IO, List[KuroganeCharacterMove]] = jsonOf
   private val kc: KuroganeClient[IO] = new KuroganeClientMock[IO]
 
-  private val router = new CharactersRoutes[IO](
+  private val router: HttpRoutes[IO] = new CharactersRoutes[IO](
     CharactersService(new CharactersInMemoryRepository[IO], kc),
     MovementsService(new MovementsInMemoryRepository[IO], kc)
   ).characterRoutes
 
   test("/characters should return characters") {
-    val response = router
+    val response: IO[Response[IO]] = router
       .orNotFound
       .run(Request[IO](method = Method.GET, uri = uri"/characters"))
     assertEquals(TestHelper.check[List[KuroganeCharacter]](response, Status.Ok, Some(TestHelper.characters)), true)

--- a/src/test/scala/io/github/locl95/smashtools/characters/service/CharactersServiceSpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/characters/service/CharactersServiceSpec.scala
@@ -21,7 +21,6 @@ class CharactersServiceSpec extends CatsEffectSuite {
     } yield (apiCharacters, dbCharacters)
     assertIO(program._1F, TestHelper.characters)
     assertIO(program._2F, TestHelper.characters)
-
   }
 
   test("Get Movements should retrieve them from api and insert them in database when cache is false") {

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/SmashggClientSpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/SmashggClientSpec.scala
@@ -9,6 +9,7 @@ import org.http4s.client.blaze.BlazeClientBuilder
 import scala.concurrent.ExecutionContext.global
 
 class SmashggClientSpec extends CatsEffectSuite {
+
   test("Should be able to retreat a tournament from smash.gg API") {
     val program: fs2.Stream[IO, Tournament] = for {
       client <- BlazeClientBuilder[IO](global).stream
@@ -18,7 +19,7 @@ class SmashggClientSpec extends CatsEffectSuite {
         .eval(smashggClient.get[Tournament](SmashggQuery.getTournamentQuery("mst-4")))
     } yield tournament
 
-    assertIO(program.compile.lastOrError, Tournament("MST 4"))
+    assertIO(program.compile.lastOrError, Tournament(312932,"MST-4"))
   }
 
   test("Should be able to retreat participants from smash.gg API") {
@@ -42,7 +43,7 @@ class SmashggClientSpec extends CatsEffectSuite {
         .eval(smashggClient.get[Event](SmashggQuery.getEvent("mst-4", "ultimate-singles", 1)))
     } yield participants
 
-    assertIO(program.compile.lastOrError, Event("Ultimate Singles"))
+    assertIO(program.compile.lastOrError, Event(615463, "Ultimate Singles"))
   }
 
   test("Should be able to retreat phases from smash.gg API") {
@@ -78,7 +79,7 @@ class SmashggClientSpec extends CatsEffectSuite {
         .eval(smashggClient.get[List[Entrant]](SmashggQuery.getEntrant("mst-4", "ultimate-singles")))
     } yield entrants
 
-    assertIO(program.compile.foldMonoid.map(i => i.contains(Entrant("Raiden's | Zandark"))), true)
+    assertIO(program.compile.foldMonoid.map(i => i.contains(Entrant(8348984, 615463, "Raiden's | Zandark"))), true)
   }
 
 }

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/SmashggRoutesSpecs.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/SmashggRoutesSpecs.scala
@@ -1,0 +1,173 @@
+package io.github.locl95.smashtools.smashgg
+
+import cats.effect._
+import io.circe.Decoder
+import io.circe.generic.auto._
+import io.circe.generic.semiauto.deriveDecoder
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.domain._
+import munit.CatsEffectSuite
+import org.http4s._
+import org.http4s.circe.CirceEntityCodec.circeEntityEncoder
+import org.http4s.circe.jsonOf
+import org.http4s.implicits.{http4sKleisliResponseSyntaxOptionT, http4sLiteralsSyntax}
+
+class SmashggRoutesSpecs extends CatsEffectSuite{
+
+  implicit private val entityDecoderForInt: EntityDecoder[IO, Int] = jsonOf
+
+  val ctx = new Context[IO]
+  val smashggRouter: SmashggRoutes[IO] = ctx.smashggRoutesProgram.compile.lastOrError.unsafeRunSync()
+  val router: HttpRoutes[IO] = smashggRouter.smashggRoutes
+
+  override def beforeAll(): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+  }
+
+  test("POST /tournaments/<tournament> should insert a tournament into tournaments migration"){
+    import io.github.locl95.smashtools.smashgg.protocol.Smashgg.tournamentEncoder
+    implicit  val decoderForTournament: Decoder[Tournament] = deriveDecoder[Tournament]
+    implicit  val entityDecoderForTournament: EntityDecoder[IO, Tournament] =
+      jsonOf
+
+    val responseInsert =
+      router.orNotFound.run(Request[IO](method = Method.POST, uri = uri"/tournaments", headers = TestHelper.headers).withEntity(TestHelper.tournament))
+
+    val responseGet =
+      router.orNotFound.run(Request[IO](method = Method.GET, uri = uri"/tournaments" / TestHelper.tournament.id.toString))
+
+    assertEquals(TestHelper.check[Int](responseInsert, Status.Ok, Some(TestHelper.tournament.id)), true)
+    assertEquals(TestHelper.check[Tournament](responseGet, Status.Ok, Some(TestHelper.tournament)), true)
+  }
+
+  test("GET /tournaments/312932 should return MST-4 tournament from tournaments migration") {
+    implicit  val decoderForTournament: Decoder[Tournament] = deriveDecoder[Tournament]
+    implicit  val entityDecoderForTournament: EntityDecoder[IO, Tournament] =
+      jsonOf
+
+    val response = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/tournaments/312932"))
+
+    assertEquals(TestHelper.check[Tournament](response, Status.Ok, Some(TestHelper.tournament)), true)
+  }
+
+  test("GET /tournaments should return tournaments from tournaments migration") {
+    implicit  val decoderForTournament: Decoder[Tournament] = deriveDecoder[Tournament]
+    implicit  val decoderForTournaments: Decoder[List[Tournament]] =
+      Decoder.decodeList[Tournament](decoderForTournament)
+    implicit  val entityDecoderForTournaments: EntityDecoder[IO, List[Tournament]] =
+      jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/tournaments"))
+
+    assertEquals(TestHelper.check[List[Tournament]](response, Status.Ok, Some(TestHelper.tournaments)), true)
+  }
+
+  test("POST /tournaments/<tournament>/events/<event> should insert an event to events migration"){
+    val resp =
+      router.orNotFound.run(Request[IO](method = Method.POST, uri = uri"/tournaments" / "312932" / "events" ).withEntity(TestHelper.testEvent))
+
+    assertEquals(TestHelper.check[Int](resp, Status.Ok, Some(615463)), true)
+  }
+
+  test("GET /tournaments/<tournament>/events should return all events from <tournament> from events migration"){
+    implicit val decoderForEvent: Decoder[Event] = deriveDecoder[Event]
+    implicit val decoderForEvents: Decoder[List[Event]] = Decoder.decodeList[Event](decoderForEvent)
+    implicit val entityDecoderForEvents: EntityDecoder[IO, List[Event]] = jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/tournaments" /"312932" /"events"))
+
+    assertEquals(TestHelper.check[List[Event]](response, Status.Ok, Some(TestHelper.events)), true)
+  }
+
+  test("GET /events should return all events from events migration"){
+    implicit val decoderForEvent: Decoder[Event] = deriveDecoder[Event]
+    implicit val decoderForEvents: Decoder[List[Event]] = Decoder.decodeList[Event](decoderForEvent)
+    implicit val entityDecoderForEvents: EntityDecoder[IO, List[Event]] = jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/events"))
+
+    assertEquals(TestHelper.check[List[Event]](response, Status.Ok, Some(TestHelper.events)), true)
+  }
+
+  test("POST /events/entrants should insert a list of entrants to entrants migration"){
+    val response =
+      router.orNotFound.run(Request[IO](method = Method.POST, uri = uri"/events/entrants").withEntity(TestHelper.entrants))
+
+    assertEquals(TestHelper.check[Int](response, Status.Ok, Some(2)), true)
+  }
+
+  test("GET /events/entrants should retrieve all entrants from entrants migration"){
+    implicit val decoderForEntrant: Decoder[Entrant] = deriveDecoder[Entrant]
+    implicit val decoderForEntrants: Decoder[List[Entrant]] = Decoder.decodeList[Entrant](decoderForEntrant)
+    implicit val entityDecoderForEntrants: EntityDecoder[IO, List[Entrant]] =
+      jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/events/entrants"))
+
+    assert(response.unsafeRunSync().as[List[Entrant]].unsafeRunSync().take(2) == TestHelper.entrants)
+  }
+
+  test("GET /events/<eventID>/entrants should retrieve all entrants that belong to <eventID> from entrants migration"){
+    implicit val decoderForEntrant: Decoder[Entrant] = deriveDecoder[Entrant]
+    implicit val decoderForEntrants: Decoder[List[Entrant]] = Decoder.decodeList[Entrant](decoderForEntrant)
+    implicit val entityDecoderForEntrants: EntityDecoder[IO, List[Entrant]] =
+      jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/events" /"615463" /"entrants"))
+
+    assert(response.unsafeRunSync().as[List[Entrant]].unsafeRunSync().contains(TestHelper.entrant))
+  }
+
+  test("POST /phases should insert phases to phases migration"){
+    val response =
+      router.orNotFound.run(Request[IO](method = Method.POST, uri = uri"/phases").withEntity(TestHelper.phases))
+
+    assertEquals(TestHelper.check[Int](response, Status.Ok, Some(2)), true)
+  }
+
+  test("GET /phases should retrieve all phases from phases migration"){
+    implicit val decoderForPhases: Decoder[List[Phase]] = Decoder.decodeList[Phase]
+    implicit val entityDecoderForPhases: EntityDecoder[IO, List[Phase]] = jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/phases"))
+
+    assertEquals(TestHelper.check[List[Phase]](response, Status.Ok, Some(TestHelper.phases)), true)
+  }
+
+  test("POST /sets should insert sets to sets migration"){
+    val response =
+      router.orNotFound.run(Request[IO](method = Method.POST, uri = uri"/sets").withEntity(TestHelper.sets))
+
+    assertEquals(TestHelper.check[Int](response, Status.Ok, Some(2)), true)
+  }
+
+  test("GET /sets should retrieve all sets from sets migration"){
+    implicit val decoderForSets: Decoder[List[Sets]] = Decoder.decodeList[Sets]
+    implicit def entityDecoderForSets: EntityDecoder[IO, List[Sets]] = jsonOf
+
+    val response: IO[Response[IO]] = router
+      .orNotFound
+      .run(Request[IO](method = Method.GET, uri = uri"/sets"))
+
+    assert(response.unsafeRunSync().as[List[Sets]].unsafeRunSync().take(2) == TestHelper.testSets)
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/TestHelper.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/TestHelper.scala
@@ -1,0 +1,153 @@
+package io.github.locl95.smashtools.smashgg
+
+import cats.effect.{IO, Sync}
+import cats.implicits._
+import io.github.locl95.smashtools.smashgg.domain._
+import io.github.locl95.smashtools.smashgg.repository._
+import org.http4s.{EntityDecoder, Header, Headers, Response, Status}
+
+import scala.collection.mutable
+
+trait InMemoryRepository {
+  def clean(): Unit
+}
+
+final class TournamentsInMemoryRepository[F[_]: Sync] extends TournamentRepository[F] with InMemoryRepository{
+  private val tournamentsList: mutable.ArrayDeque[Tournament] = mutable.ArrayDeque.empty
+  override def toString: String = "TournamentsInMemoryRepository"
+  override def insert(tournament: Tournament): F[Int] = {
+    tournamentsList.append(tournament).pure[F]
+    tournament.id.pure[F]
+  }
+  override def clean(): Unit = {
+    tournamentsList.clearAndShrink()
+  }
+  override def get: F[List[Tournament]] =
+    tournamentsList.toList.pure[F]
+
+  override def get(id: Int): F[Option[Tournament]] =
+    tournamentsList.find(_.id == id).pure[F]
+}
+
+final class EntrantInMemoryRepository[F[_]: Sync] extends EntrantRepository[F] with InMemoryRepository {
+  private val entrantsArray: mutable.ArrayDeque[Entrant] = mutable.ArrayDeque.empty
+  override def toString:String =
+    "EntrantInMemoryRepository"
+  override def insert(entrants: List[Entrant]): F[Int] = {
+    entrantsArray.appendAll(entrants).pure[F]
+    entrantsArray.size.pure[F]
+  }
+
+  override def getEntrants(eventID: Int): F[List[Entrant]] =
+    entrantsArray.filter(x => x.idEvent == eventID).toList.pure[F]
+
+  override def getEntrants: F[List[Entrant]] =
+    entrantsArray.toList.pure[F]
+
+  override def clean(): Unit =
+    entrantsArray.clearAndShrink()
+}
+
+final class EventInMemoryRepository[F[_]: Sync] extends EventRepository[F] with InMemoryRepository {
+  private val eventsArray: mutable.ArrayDeque[Event] = mutable.ArrayDeque.empty
+  override def toString:String =
+    "EventInMemoryRepository"
+  override def insert(event: Event): F[Int] = {
+    eventsArray.append(event).pure[F]
+    event.id.pure[F]
+  }
+  override def clean(): Unit =
+    eventsArray.clearAndShrink()
+
+  override def get: F[List[Event]] =
+    eventsArray.toList.pure[F]
+
+  override def getEvents(tournament: Int): F[List[Event]] =
+    eventsArray.toList.filter(_.idTournament == tournament).pure[F]
+}
+
+final class PlayerStandingInMemoryRepository[F[_]: Sync] extends PlayerStandingRepository[F] with InMemoryRepository {
+  private val playerStandingsArray: mutable.ArrayDeque[PlayerStanding] = mutable.ArrayDeque.empty
+  override def toString:String =
+    "PlayerStandingInMemoryRepository"
+  override def insert(playerStanding: List[PlayerStanding]): F[Int] = {
+    playerStandingsArray.appendAll(playerStanding).pure[F]
+    playerStandingsArray.size.pure[F]
+  }
+  override def clean(): Unit =
+    playerStandingsArray.clearAndShrink()
+
+  override def getPlayerStandings: F[List[PlayerStanding]] =
+    playerStandingsArray.toList.pure[F]
+}
+
+final class PhaseInMemoryRepository[F[_]: Sync] extends PhaseRepository[F] with InMemoryRepository {
+  private val phashesArray: mutable.ArrayDeque[Phase] = mutable.ArrayDeque.empty
+  override def toString:String =
+    "PhaseInMemoryRepository"
+  override def insert(phases: List[Phase]): F[Int] = {
+    phashesArray.appendAll(phases).pure[F]
+    phashesArray.size.pure[F]
+  }
+  override def clean(): Unit =
+    phashesArray.clearAndShrink()
+
+  override def getPhases: F[List[Phase]] =
+    phashesArray.toList.pure[F]
+}
+
+final class SetsInMemoryRepository[F[_]: Sync] extends SetsRepository[F] with InMemoryRepository
+{
+  private val setsArray: mutable.ArrayDeque[Sets] = mutable.ArrayDeque.empty
+  override def toString:String =
+    "SetsInMemoryRepository"
+  override def insert(sets: List[Sets]): F[Int] = {
+    setsArray.appendAll(sets).pure[F]
+    setsArray.size.pure[F]
+  }
+  override def clean(): Unit =
+    setsArray.clearAndShrink()
+
+  override def getSets: F[List[Sets]] =
+    setsArray.toList.pure[F]
+}
+
+object TestHelper {
+  val tournament: Tournament = Tournament(312932,"MST-4")
+  val tournaments: List[Tournament] = List(Tournament(312932,"MST-4"))
+
+  val participants:List[Participant] =
+    List(
+      Participant(List(8022537)),
+      Participant(List(7914930)),
+      Participant(List(7919929, 7914930))
+    )
+  val entrant: Entrant = Entrant(8348984, 615463, "Raiden's | Zandark")
+  val entrants: List[Entrant] = List(Entrant(8348984, 615463, "Raiden's | Zandark"), Entrant(8346516, 615463, "FS | Sevro"))
+  val event: Event = Event(615463, "Ultimate Singles")
+  val testEvent: Event = Event(615463, "Ultimate Singles", 312932)
+  val events: List[Event] = List(Event(615463, "Ultimate Singles", 312932))
+  val playerStandings: List[PlayerStanding] = List(PlayerStanding(1,8232866), PlayerStanding(2,8280489))
+  val phases: List[Phase] = List(Phase(991477, "Bracket Pools"), Phase(991478, "Top 16"))
+  val sets: List[Sets] = List(Sets(40865697,615463,List(Score(8280489,0),Score(8232866,3))), Sets(40865698,615463,List(Score(8232866,3),Score(8280489,2))))
+  val testSets: List[Sets] = List(Sets(40865697,615463, List(Score(8232866, 3), Score(8280489, 0))), Sets(40865698,615463, List(Score(8232866, 3), Score(8280489, 2))))
+
+  val headers: Headers = Headers.apply(
+    Header("Authorization", "Bearer 3305177ceda157c60fbc09b79e2ff987")
+  )
+
+  def check[A](actual:        IO[Response[IO]],
+               expectedStatus: Status,
+               expectedBody:   Option[A])(
+                implicit ev: EntityDecoder[IO, A]
+              ): Boolean =  {
+    val actualResp         = actual.unsafeRunSync()
+    val statusCheck        = actualResp.status == expectedStatus
+    val bodyCheck          = expectedBody.fold[Boolean](
+      // Verify Response's body is empty.
+      actualResp.body.compile.toVector.unsafeRunSync().isEmpty)(
+      expected => actualResp.as[A].unsafeRunSync() == expected
+    )
+    statusCheck && bodyCheck
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/protocol/SmashggSpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/protocol/SmashggSpec.scala
@@ -3,6 +3,7 @@ package io.github.locl95.smashtools.smashgg.protocol
 import munit.CatsEffectSuite
 import io.circe.syntax._
 import io.circe.parser._
+import io.github.locl95.smashtools.smashgg.TestHelper
 import io.github.locl95.smashtools.smashgg.domain.{Entrant, Event, Participant, Phase, PlayerStanding, SmashggQuery, Tournament}
 import io.github.locl95.smashtools.smashgg.protocol.Smashgg._
 
@@ -14,7 +15,7 @@ class SmashggSpec extends CatsEffectSuite {
 
   test("I can decode smash.gg tournament") {
     val tournamentJson = scala.io.Source.fromFile(s"src/test/resources/smashgg/smashgg-tournament.json")
-    val expectedTournament = Tournament("MST 4")
+    val expectedTournament = Tournament(312932,"MST-4")
 
     val tournamentFromJson =
       for {
@@ -23,7 +24,6 @@ class SmashggSpec extends CatsEffectSuite {
       } yield tournament
 
     assert(tournamentFromJson.contains(expectedTournament))
-
   }
 
   test("I can decode smash.gg participants") {
@@ -52,12 +52,12 @@ class SmashggSpec extends CatsEffectSuite {
         event <- eventDecoder.decodeJson(json)
       } yield event
 
-    assert(eventFromJson.contains(Event("Ultimate Singles")))
+    assert(eventFromJson.contains(Event(615463, "Ultimate Singles")))
   }
 
   test("I can decode smash.gg entrants"){
     val eventJson = scala.io.Source.fromFile(s"src/test/resources/smashgg/smashgg-entrants.json")
-    val expectedTwoFirstEntrants = List(Entrant("Raiden's | Zandark"), Entrant("FS | Sevro"))
+    val expectedTwoFirstEntrants = List(Entrant(8348984, 615463, "Raiden's | Zandark"), Entrant(8346516, 615463, "FS | Sevro"))
 
     val entrantsFromJson =
       for {
@@ -94,5 +94,19 @@ class SmashggSpec extends CatsEffectSuite {
     assert(phasesFromJson.map(_.take(2)).contains(expectedTwoFirstPhases))
 
   }
+
+  test("I can decode smash.gg sets") {
+    val eventJson = scala.io.Source.fromFile(s"src/test/resources/smashgg/smashgg-events.json")
+    val expectedTwoFirstSets = TestHelper.sets
+
+    val setsFromJson =
+      for {
+        json <- parse(eventJson.getLines().mkString)
+        sets <- setsDecoder.decodeJson(json)
+      } yield sets
+
+    assert(setsFromJson.map(_.take(2)).contains(expectedTwoFirstSets))
+  }
+
 
 }

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/EntrantsRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/EntrantsRepositorySpec.scala
@@ -1,0 +1,42 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{EntrantInMemoryRepository, TestHelper}
+import munit.CatsEffectSuite
+
+class EntrantsRepositorySpec extends CatsEffectSuite{
+
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private val inMemory = new EntrantInMemoryRepository[IO]
+  private val postgres = new EntrantPostgresRepository[IO](tx)
+  private val repositories = List(inMemory, postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+    inMemory.clean()
+  }
+
+  private val insertTest = (repo: EntrantRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.entrants)
+    } yield result == 2)
+
+  private val getTest = (repo: EntrantRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.entrants)
+      result <- repo.getEntrants
+    } yield result == TestHelper.entrants)
+
+  repositories.foreach { r =>
+    test(s"Given some entrants I can insert them with $r") { insertTest(r)}
+    test(s"Given some entrants I can retrieve them with $r") { getTest(r)}
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/EventsRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/EventsRepositorySpec.scala
@@ -1,0 +1,44 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{EventInMemoryRepository, TestHelper}
+import munit.CatsEffectSuite
+
+class EventsRepositorySpec extends CatsEffectSuite{
+
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private val inMemory = new EventInMemoryRepository[IO]
+  private val postgres = new EventPostgresRepository[IO](tx)
+  private val repositories = List(inMemory, postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+    inMemory.clean()
+  }
+
+  private val insertTest = (repo: EventRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.event)
+    } yield result == TestHelper.event.id)
+
+  private val getTest = (repo: EventRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.event)
+      result <- repo.get
+    } yield result == List(TestHelper.event))
+
+
+  repositories.foreach { r =>
+    test(s"Given some events I can insert them with $r") { insertTest(r) }
+    test(s"Given some events I can retrieve them with $r") { getTest(r) }
+  }
+}
+

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/PhaseRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/PhaseRepositorySpec.scala
@@ -1,0 +1,41 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{PhaseInMemoryRepository, TestHelper}
+import munit.CatsEffectSuite
+
+class PhaseRepositorySpec extends CatsEffectSuite{
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private val inMemory = new PhaseInMemoryRepository[IO]
+  private val postgres = new PhasePostgresRepository[IO](tx)
+  private val repositories = List(postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+    inMemory.clean()
+  }
+
+  private val insertTest = (repo: PhaseRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.phases)
+    } yield result == 2)
+
+  private val getTest = (repo: PhaseRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.phases)
+      result <- repo.getPhases
+    } yield result == TestHelper.phases)
+
+  repositories.foreach { r =>
+    test(s"Given some phases I can insert them with $r") { insertTest(r) }
+    test(s"Given some phases I can retrieve them with $r") { getTest(r) }
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/PlayerStandingRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/PlayerStandingRepositorySpec.scala
@@ -1,0 +1,41 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{PlayerStandingInMemoryRepository, TestHelper}
+import munit.CatsEffectSuite
+
+class PlayerStandingRepositorySpec extends CatsEffectSuite{
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private val inMemory = new PlayerStandingInMemoryRepository[IO]
+  private val postgres = new PlayerStandingPostgresRepository[IO](tx)
+  private val repositories = List(inMemory, postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+    inMemory.clean()
+  }
+
+  private val insertTest = (repo: PlayerStandingRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.playerStandings)
+    } yield result == 2)
+
+  private val getTest = (repo: PlayerStandingRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.playerStandings)
+      result <- repo.getPlayerStandings
+    } yield result == TestHelper.playerStandings)
+
+  repositories.foreach { r =>
+    test(s"Given some player standings I can insert them with $r") { insertTest(r) }
+    test(s"Given some player standings I can retrieve them with $r") { getTest(r) }
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/SetsRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/SetsRepositorySpec.scala
@@ -1,0 +1,46 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{SetsInMemoryRepository, TestHelper}
+import munit.CatsEffectSuite
+
+class SetsRepositorySpec extends CatsEffectSuite {
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private val inMemory = new SetsInMemoryRepository[IO]
+  private val postgres = new SetsPostgresRepository[IO](tx)
+  private val repositories = List(inMemory, postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+    inMemory.clean()
+  }
+
+  private val insertTest = (repo: SetsRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.testSets)
+    } yield result == 2)
+
+  private val getTest = (repo: SetsRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.testSets)
+      result <- repo.getSets
+    } yield result == TestHelper.testSets)
+
+
+  repositories.foreach { r =>
+    test(s"Given some sets I can insert them with $r") {
+      insertTest(r)
+    }
+    test(s"Given some sets I can retrieve them with $r") {
+      getTest(r)
+    }
+  }
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/repository/TournamentRepositorySpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/repository/TournamentRepositorySpec.scala
@@ -1,0 +1,45 @@
+package io.github.locl95.smashtools.smashgg.repository
+
+import cats.effect.IO
+import io.github.locl95.smashtools.Context
+import io.github.locl95.smashtools.smashgg.{TestHelper, TournamentsInMemoryRepository}
+import munit.CatsEffectSuite
+
+class TournamentRepositorySpec extends CatsEffectSuite{
+  val ctx = new Context[IO]
+  val tx = ctx.databaseProgram.unsafeRunSync().transactor
+
+  private def inMemory = new TournamentsInMemoryRepository[IO]
+  private def postgres = new TournamentPostgresRepository[IO](tx)
+  private def repositories: List[TournamentRepository[IO]] = List(inMemory, postgres)
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    val migrate = for {
+      dbProgram <- ctx.databaseProgram
+      _ = dbProgram.flyway.clean()
+      _ = dbProgram.flyway.migrate()
+    } yield ()
+    migrate.unsafeRunSync()
+  }
+
+  private val insertTournamentTest = (repo: TournamentRepository[IO]) =>
+    assertIOBoolean(for {
+      result <- repo.insert(TestHelper.tournament)
+    } yield result == TestHelper.tournament.id)
+
+  private val getTournamentsTest = (repo: TournamentRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.tournament)
+      result <- repo.get
+    } yield result.take(1) == List(TestHelper.tournament))
+
+  private val getTournamentByIdTest = (repo: TournamentRepository[IO]) =>
+    assertIOBoolean(for {
+      _ <- repo.insert(TestHelper.tournament)
+      result <- repo.get(312932)
+    } yield result.get == TestHelper.tournament)
+
+  repositories.foreach (r => test(s"Given some tournaments I can insert them with $r") { insertTournamentTest(r)})
+  repositories.foreach (r => test(s"Given some tournaments in bdd I can retrieve them with $r") { getTournamentsTest(r)})
+  repositories.foreach (r => test(s"Given some tournaments in bdd I can retrieve certain tournament by with $r") { getTournamentByIdTest(r)})
+}

--- a/src/test/scala/io/github/locl95/smashtools/smashgg/service/SmashggServiceSpec.scala
+++ b/src/test/scala/io/github/locl95/smashtools/smashgg/service/SmashggServiceSpec.scala
@@ -1,0 +1,37 @@
+package io.github.locl95.smashtools.smashgg.service
+
+import cats.effect.IO
+import cats.implicits.catsSyntaxFunctorTuple2Ops
+import io.github.locl95.smashtools.smashgg.{SmashggClient, TestHelper, TournamentsInMemoryRepository}
+import munit.CatsEffectSuite
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
+
+import scala.concurrent.ExecutionContext.global
+
+class SmashggServiceSpec extends CatsEffectSuite{
+
+  val program: fs2.Stream[IO, Client[IO]] = for {
+    client <- BlazeClientBuilder[IO](global).stream
+  } yield client
+
+  val client: Client[IO] = program.compile.lastOrError.unsafeRunSync()
+  val smashggClient: SmashggClient[IO] = SmashggClient.impl(client)
+
+  test("Retrieve tournaments from api and insert and get them in data"){
+    val repository = new TournamentsInMemoryRepository[IO]
+
+    val program = for {
+      apiTournaments <- {
+        for {
+          _ <- TournamentService(repository, smashggClient).insert(TestHelper.tournament)
+          tournaments  <- TournamentService(repository, smashggClient).get
+        } yield tournaments
+      }
+      dbTournaments <- repository.get
+    } yield (apiTournaments, dbTournaments)
+
+    assertIO(program._1F, TestHelper.tournaments)
+    assertIO(program._2F, TestHelper.tournaments)
+  }
+}


### PR DESCRIPTION
* Queries, decoder, decoderEntity of Phase, Entrant, PlayerStanding

* To test

* Tests repo tournament

* Tournament repo

* Working on repos

* Event & Entrant repos

* Repos finished

* Sets smashgg

* Read Sets from Json

* Tournament Event Entrant refactorized

* Smashgg repos done and tested

* Tournament endpoint

* SmashtoolsServer smashgg routes

* Tournament HttpRutes and Tournament Routes Specs

* Tournament Test Service

* Event routes and test

* SmashggRoutes and test

* Smashgg Entities Api and Tests

* PR requested changes

* Sequential tests + test refactoring

Co-authored-by: locl95 <54895253+locl95@users.noreply.github.com>